### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ You can enable Wide Angle Analytics in your Nuxt projects in just a few steps. N
 2. [Create a new site](https://wideangle.co/documentation/create-and-configure-site) and activate it.
 3. Install the `wideangle-vuejs` plugin in your Vue application.
 
-```npx nuxi@latest module add wideangle
+```bash
+npx nuxi@latest module add wideangle
+```
 
 4. Enable and configure the module.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can enable Wide Angle Analytics in your Nuxt projects in just a few steps. N
 2. [Create a new site](https://wideangle.co/documentation/create-and-configure-site) and activate it.
 3. Install the `wideangle-vuejs` plugin in your Vue application.
 
-```npm install wideangle-nuxt```
+```npx nuxi@latest module add wideangle
 
 4. Enable and configure the module.
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
